### PR TITLE
Add support for Docker BuildKit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,20 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           tag-latest: true
           additional-tags: firstTag, secondTag
+
+  test-buildkit:
+    name: Test with buildkit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - run: npm ci
+      - run: npm run build
+      - uses: ./
+        with:
+          dockerfile: testdata/Dockerfile.buildkit
+          buildkit: true
+          repository: jen20/test-action-docker-build-additional-tags
+          username: jen20
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          tag-latest: true

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Path of the Dockerfile to build relative to the repository root
     required: false
     default: Dockerfile
+  buildkit:
+    description: Whether or not to enable Docker BuildKit
+    required: false
+    default: 'false'
   registry:
     description: Registry address to which to push the container image
     required: false
@@ -21,13 +25,13 @@ inputs:
   tag-latest:
     description: Whether or not to tag the container image as "latest" in addition to other tags specified.
     required: false
-    default: false
+    default: 'false'
   tag-snapshot:
     description: |
       Whether or not to create a snapshot tag containing the build timestamp and commit SHA in addition to
       other tags specified.
     required: false
-    default: false
+    default: 'false'
   additional-tags:
     description: Comma-separated list of tags to apply to the container image
     required: false

--- a/testdata/Dockerfile.buildkit
+++ b/testdata/Dockerfile.buildkit
@@ -1,0 +1,2 @@
+# syntax = docker/dockerfile:experimental
+FROM hello-world:latest


### PR DESCRIPTION
This PR adds support for building containers using the Docker BuildKit system, which results in exporting `DOCKER_BUILDKIT=true` to the build command.