### PR TITLE
Allow stripping leading "refs/tags/" from additionalTags values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,8 @@ jobs:
           username: jen20
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           tag-latest: true
-          additional-tags: firstTag, secondTag
+          additional-tags: firstTag, secondTag, refs/tags/v1.0.0
+          strip-refs-tags: true
 
   test-buildkit:
     name: Test with buildkit

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
   additional-tags:
     description: Comma-separated list of tags to apply to the container image
     required: false
+  strip-refs-tags:
+    description: Whether or not to strip a leading "refs/tags/" from values in additional-tags
+    required: false
+    default: 'true'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,7 @@ const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
 const moment = require("moment");
 const child_process = __importStar(require("child_process"));
+const refsTagsPrefix = "refs/tags/";
 function isNullOrWhitespace(input) {
     if (typeof input === 'undefined' || input == null) {
         return true;
@@ -52,6 +53,7 @@ function validatePlatform() {
 function readAndValidateConfig() {
     const config = {
         dockerfile: core.getInput("dockerfile"),
+        buildkit: core.getInput("buildkit") == "true",
         repository: core.getInput("repository"),
         registry: core.getInput("registry"),
         username: core.getInput("username"),
@@ -62,6 +64,7 @@ function readAndValidateConfig() {
             .split(",")
             .map(x => x.trim())
             .filter(x => !isNullOrWhitespace(x)),
+        stripRefsTags: core.getInput("strip-refs-tags") != "false",
     };
     if (config.repository == "") {
         core.setFailed("Repository is required.");
@@ -105,6 +108,15 @@ function run() {
             if (config == undefined) {
                 return;
             }
+            let effectiveAdditionalTags = config.additionalTags;
+            if (config.stripRefsTags) {
+                effectiveAdditionalTags = config.additionalTags.map(val => {
+                    if (!val.startsWith(refsTagsPrefix)) {
+                        return val;
+                    }
+                    return val.substr(refsTagsPrefix.length);
+                });
+            }
             core.info("Logging into Docker registry");
             dockerLogin(config);
             core.info("Constructing `docker build` command line");
@@ -119,15 +131,20 @@ function run() {
                 snapshotId = `${snapshotDate}-${commitSHA}`;
                 buildParams.push("-t", `${config.repository}:${snapshotId}`);
             }
-            for (const tag of config.additionalTags) {
+            for (const tag of effectiveAdditionalTags) {
                 buildParams.push("-t", `${config.repository}:${tag}`);
+            }
+            const env = {};
+            if (config.buildkit) {
+                env["DOCKER_BUILDKIT"] = "true";
             }
             core.info("Building Docker Image...");
             buildParams.push(".");
-            const inDockerfileDirOptions = {
+            const dockerOptions = {
                 cwd: path.dirname(config.dockerfile),
+                env: env,
             };
-            yield exec_1.exec("docker", buildParams, inDockerfileDirOptions);
+            yield exec_1.exec("docker", buildParams, dockerOptions);
             if (config.tagLatest) {
                 core.info(`Pushing '${config.repository}:latest' to registry...`);
                 yield exec_1.exec("docker", ["push", `${config.repository}:latest`]);
@@ -136,8 +153,7 @@ function run() {
                 core.info(`Pushing '${config.repository}:${snapshotId}' to registry...`);
                 yield exec_1.exec("docker", ["push", `${config.repository}:${snapshotId}`]);
             }
-            for (const tag of config.additionalTags) {
-                core.info(`Pushing '${config.repository}:${tag}' to registry...`);
+            for (const tag of effectiveAdditionalTags) {
                 yield exec_1.exec("docker", ["push", `${config.repository}:${tag}`]);
             }
         }


### PR DESCRIPTION
If you use `${{ github.refs }}` for an additional tag, it's likely to have `refs/tags/` prefixed. This could be removed with a script step but it seems likely that this will be a common requirement and should have first class support instead.